### PR TITLE
Add bazel BUILD file.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,14 +1,25 @@
 load(
     "@tenx_bazel_rules//rules:cargo.bzl",
     "cargo_binary",
+    "cargo_dependencies",
 )
 
-exports_files([
-    "Cargo.toml",
-    "Cargo.lock",
-])
+exports_files(
+    [
+        "Cargo.toml",
+        "Cargo.lock",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cargo_dependencies(
+    name = "bamtofastq_dependencies",
+    fetch = "@bamtofastq_cargo_dependencies",
+)
 
 cargo_binary(
     name = "bamtofastq",
+    cargo_deps = ":bamtofastq_dependencies",
+    srcs = glob(["src/**"]),
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,6 @@
 load(
     "@tenx_bazel_rules//rules:cargo.bzl",
     "cargo_binary",
-    "cargo_dependencies",
 )
 
 exports_files(
@@ -12,14 +11,9 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
-cargo_dependencies(
-    name = "bamtofastq_dependencies",
-    fetch = "@bamtofastq_cargo_dependencies",
-)
-
 cargo_binary(
     name = "bamtofastq",
-    cargo_deps = ":bamtofastq_dependencies",
+    cargo_deps = "@bamtofastq_cargo_dependencies",
     srcs = glob(["src/**"]),
     visibility = ["//visibility:public"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,7 @@ load(
 # --override_repository=tenx_bazel_rules=/path/to/repository
 git_repository(
     name = "tenx_bazel_rules",
-    commit = "c9eb70d1dd6166dfe3273b8abb30ee92edf379d3",
+    commit = "69af1bc334dc631d16c928af61ef0e27d8157d91",
     remote = "https://github.com/10XDev/tenx_bazel_rules.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,42 @@
+workspace(name = "bamtofastq")
+
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+# When debugging iteratively, it's useful to switch to a local repo rather
+# than repeated pushes to github.  To do this, run with
+# --override_repository=tenx_bazel_rules=/path/to/repository
+git_repository(
+    name = "tenx_bazel_rules",
+    commit = "c9eb70d1dd6166dfe3273b8abb30ee92edf379d3",
+    remote = "https://github.com/10XDev/tenx_bazel_rules.git",
+)
+
+load(
+    "@tenx_bazel_rules//:deps.bzl",
+    "toolchain_dependencies",
+)
+
+toolchain_dependencies()
+
+load(
+    "@tenx_bazel_rules//:toolchains.bzl",
+    "register_pipeline_toolchains",
+)
+
+register_pipeline_toolchains()
+
+load(
+    "@tenx_bazel_rules//rules:cargo_repository.bzl",
+    "cargo_repository",
+)
+
+cargo_repository(
+    name = "bamtofastq_cargo_dependencies",
+    lockfile = ":Cargo.lock",
+    srcs = [
+        ":Cargo.toml",
+    ],
+)


### PR DESCRIPTION
These build files depend on cargo build rules which we are not (yet) ready to
publish, however community users can still build with cargo (and, because
those rules go through cargo, should yield identical results).