### PR TITLE
Cargo.toml: Optimize debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,9 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 [profile.release]
 debug = 1
 lto = true
+
+[profile.dev]
+opt-level = 3
+
+[profile.test]
+opt-level = 3


### PR DESCRIPTION
Set `opt-level = 3` for both `profile.dev` and `profile.test`.
