### PR TITLE
Prepare binaries for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,100 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Build and Upload Release
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@master
+      - name: Login to GitHub Package Registry
+        run: docker login docker.pkg.github.com -u 10xbuild -p ${{secrets.GH_PAT}}
+      - name: Make release build
+        run: >
+          docker run -v ${{github.workspace}}:/root
+          docker.pkg.github.com/10xdev/toolchain-scripts/toolchain:latest
+          /bin/bash -leuxc '
+          apt-get update;
+          apt-get install -y --no-install-recommends ca-certificates;
+          cargo build --release;
+          target/release/bamtofastq --help | grep -q USAGE;
+          readelf -V target/release/bamtofastq;
+          ';
+          mkdir ${{runner.temp}}/artifacts;
+          cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq-linux
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: bamtofastq
+          path: ${{runner.temp}}/artifacts
+  macos:
+    runs-on: macos-10.15
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.9
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@master
+      - name: Make release build
+        run: |
+          cargo build --release
+          target/release/bamtofastq --help | grep -q USAGE
+          mkdir ${{runner.temp}}/artifacts
+          cp -a target/release/bamtofastq artifacts/bamtofastq-macos
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: bamtofastq
+          path: ${{runner.temp}}/artifacts
+
+  setup-release:
+    needs: [linux, macos]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: bamtofastq
+          path: ${{runner.temp}}/artifacts
+
+      - run: ls ${{runner.temp}}/artifacts
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          tag_name: ${{github.ref}}
+          release_name: Release ${{github.ref}}
+          draft: false
+          prerelease: false
+
+      - name: Upload Linux
+        id: upload-linux-release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{runner.temp}}/artifacts/bamtofastq-linux
+          asset_name: bamtofastq_linux
+          asset_content_type: application/octet-stream
+
+      - name: Upload Mac
+        id: upload-mac-release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{runner.temp}}/artifacts/enclone-macos
+          asset_name: bamtofastq_macos
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,19 @@ jobs:
       - name: Make release build
         run: >
           docker run -v ${{github.workspace}}:/root
-          quay.io/pypa/manylinux2014_x86_64:latest
+          centos:centos7
           /bin/bash -leuxc '
+          yum -y reinstall glibc-common;
+          yum -y install centos-release-scl-rh;
+          yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm;
+          yum -y install devtoolset-10-binutils devtoolset-10-gcc cmake3;
+          alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \
+              --slave /usr/local/bin/ctest ctest /usr/bin/ctest3 \
+              --slave /usr/local/bin/cpack cpack /usr/bin/cpack3 \
+              --slave /usr/local/bin/ccmake ccmake /usr/bin/ccmake3 \
+              --family cmake;
+          export PATH=$PATH:/opt/rh/devtoolset-10/root/bin;
+
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable;
           source $HOME/.cargo/env;
           cd /root;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,18 +16,18 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@master
-      - name: Login to GitHub Package Registry
-        run: docker login docker.pkg.github.com -u 10xbuild -p ${{secrets.GH_PAT}}
       - name: Make release build
         run: >
           docker run -v ${{github.workspace}}:/root
-          docker.pkg.github.com/10xdev/toolchain-scripts/toolchain:latest
+          quay.io/pypa/manylinux2014_x86_64:latest
           /bin/bash -leuxc '
-          apt-get update;
-          apt-get install -y --no-install-recommends ca-certificates;
+          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable;
+          source $HOME/.cargo/env;
+          cd /root;
           cargo build --release;
-          target/release/bamtofastq --help | grep -q USAGE;
+          target/release/bamtofastq --help | grep -q Usage;
           readelf -V target/release/bamtofastq;
+          ldd target/release/bamtofastq;
           ';
           mkdir ${{runner.temp}}/artifacts;
           cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq-linux
@@ -46,9 +46,10 @@ jobs:
       - name: Make release build
         run: |
           cargo build --release
-          target/release/bamtofastq --help | grep -q USAGE
+          target/release/bamtofastq --help | grep -q Usage
+          otool -L target/release/bamtofastq
           mkdir ${{runner.temp}}/artifacts
-          cp -a target/release/bamtofastq artifacts/bamtofastq-macos
+          cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq-macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v1
         with:
@@ -95,6 +96,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{runner.temp}}/artifacts/enclone-macos
+          asset_path: ${{runner.temp}}/artifacts/bamtofastq-macos
           asset_name: bamtofastq_macos
           asset_content_type: application/octet-stream


### PR DESCRIPTION
Add a release workflow to GitHub CI, following [enclone] and [vartrix] CI examples.

[enclone]: https://github.com/10XGenomics/enclone/blob/master/.github/workflows/release.yaml
[vartrix]: https://github.com/10XGenomics/vartrix/blob/master/.github/workflows/release.yaml