### PR TITLE
Bump Rust to 1.58.1 in CI and clippy cleanups

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,11 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@master
-      - name: rust version
-        run: rustup default 1.58.1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          default: true
       - name: Make release build
         run: |
           cargo build --release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@master
+      - name: rust version
+        run: rustup default 1.58.1
       - name: Make release build
         run: |
           cargo build --release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: rust version
-        run: rustup default 1.44.0
+        run: rustup default 1.58.1
       - name: add rustfmt 
         run: rustup component add rustfmt
       - name: Checkout bamtofastq master
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: rust version
-        run: rustup default 1.55.0
+        run: rustup default 1.58.1
       - name: add rustfmt
         run: rustup component add rustfmt clippy
       - name: Checkout bamtofastq master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,12 @@ jobs:
     # This job runs on MacOS Catalina
     runs-on: macos-latest
     steps:
-      - name: rust version
-        run: rustup default 1.58.1
-      - name: add rustfmt 
-        run: rustup component add rustfmt
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          components: rustfmt
+          default: true
       - name: Checkout bamtofastq master
         uses: actions/checkout@master
       - name: Check Rust formatting
@@ -31,10 +33,12 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
-      - name: rust version
-        run: rustup default 1.58.1
-      - name: add rustfmt
-        run: rustup component add rustfmt clippy
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          components: rustfmt, clippy
+          default: true
       - name: Checkout bamtofastq master
         uses: actions/checkout@master
       - name: Check Rust formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bamtofastq"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Patrick Marks <patrick@10xgenomics.com>"]
 license = "MIT"
 repository = "https://github.com/10XGenomics/bamtofastq.git"

--- a/src/bx_index.rs
+++ b/src/bx_index.rs
@@ -64,7 +64,7 @@ impl BxIndex {
 pub fn get_records_for_bx<R: Read>(
     index: &BxIndex,
     reader: &mut R,
-    bx: &String,
+    bx: &str,
 ) -> Result<Vec<Record>, Error> {
     let start = index.get_voffset(bx);
     reader.seek(start as i64)?;
@@ -78,9 +78,9 @@ pub fn get_records_for_bx<R: Read>(
             _ => "".to_string(),
         };
 
-        if &bx_read == bx {
+        if bx_read == bx {
             recs.push(rec);
-        } else if &bx_read < bx {
+        } else if bx_read.as_str() < bx {
             continue;
         } else {
             break;
@@ -150,9 +150,8 @@ impl<R: Read> Iterator for BxListIter<R> {
                 self.cur_vec.reverse();
             }
 
-            match self.cur_vec.pop() {
-                Some(v) => return Some(Ok(v)),
-                None => (),
+            if let Some(v) = self.cur_vec.pop() {
+                return Some(Ok(v));
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -646,7 +646,7 @@ impl FormatBamRecords {
     }
 }
 
-type BGW = ThreadProxyWriter<BufWriter<GzEncoder<File>>>;
+type Bgw = ThreadProxyWriter<BufWriter<GzEncoder<File>>>;
 
 struct FastqManager {
     writers: HashMap<Rg, FastqWriter>,
@@ -724,10 +724,10 @@ struct FastqWriter {
     sample_name: String,
     lane: u32,
 
-    r1: Option<BGW>,
-    r2: Option<BGW>,
-    i1: Option<BGW>,
-    i2: Option<BGW>,
+    r1: Option<Bgw>,
+    r2: Option<Bgw>,
+    i1: Option<Bgw>,
+    i2: Option<Bgw>,
 
     chunk_written: usize,
     total_written: usize,
@@ -858,7 +858,7 @@ impl FastqWriter {
         }
     }
 
-    pub fn write_rec(w: &mut BGW, rec: &FqRecord) -> Result<(), Error> {
+    pub fn write_rec(w: &mut Bgw, rec: &FqRecord) -> Result<(), Error> {
         w.write_all(b"@")?;
         w.write_all(&rec.head)?;
         w.write_all(b"\n")?;
@@ -870,7 +870,7 @@ impl FastqWriter {
         Ok(())
     }
 
-    pub fn try_write_rec(w: &mut Option<BGW>, rec: &Option<FqRecord>) -> Result<(), Error> {
+    pub fn try_write_rec(w: &mut Option<Bgw>, rec: &Option<FqRecord>) -> Result<(), Error> {
         if let Some(ref mut w) = w {
             if let Some(r) = rec {
                 FastqWriter::write_rec(w, r)?;
@@ -882,7 +882,7 @@ impl FastqWriter {
         Ok(())
     }
 
-    pub fn try_write_rec2(w: &mut Option<BGW>, rec: &FqRecord) -> Result<(), Error> {
+    pub fn try_write_rec2(w: &mut Option<Bgw>, rec: &FqRecord) -> Result<(), Error> {
         if let Some(ref mut w) = w {
             FastqWriter::write_rec(w, rec)?;
         };
@@ -1297,8 +1297,8 @@ mod tests {
 
     type ReadSet = HashMap<Vec<u8>, RawReadSet>;
 
-    fn strip_extra_headers(header: &Vec<u8>) -> Vec<u8> {
-        let head_str = String::from_utf8(header.clone()).unwrap();
+    fn strip_extra_headers(header: &[u8]) -> Vec<u8> {
+        let head_str = String::from_utf8(header.to_owned()).unwrap();
         let mut split = head_str.split_whitespace();
         split.next().unwrap().to_string().into_bytes()
     }
@@ -1378,7 +1378,7 @@ mod tests {
         assert_eq!(v1.2, v2.2)
     }
 
-    pub fn compare_bytes_ignore_n(v1: &Vec<u8>, v2: &Vec<u8>) {
+    pub fn compare_bytes_ignore_n(v1: &[u8], v2: &[u8]) {
         assert_eq!(v1.len(), v2.len());
         for (idx, (b1, b2)) in v1.iter().zip(v2).enumerate() {
             if idx >= 16 && b1 != b2 && *b2 != b'N' && *b2 != b'J' {

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,9 +365,8 @@ impl FormatBamRecords {
                             if el == "SEQ:QUAL" {
                                 SpecEntry::Read
                             } else {
-                                let mut parts = el.split(':');
-                                let rtag = parts.next().unwrap().to_string();
-                                let qtag = parts.next().unwrap().to_string();
+                                let (rtag, qtag) =
+                                    el.split(':').map(ToString::to_string).next_tuple().unwrap();
                                 SpecEntry::Tags(rtag, qtag)
                             }
                         })


### PR DESCRIPTION
Use a consistent Rust version in CI, and fix clippy lints (both old and introduced with the Rust version bump)