### PR TITLE
Document release process and fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,8 @@
-on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+name: Build and upload binaries to Release
 
-name: Build and Upload Release
+on:
+  release:
+    types: [published]
 
 env:
   CARGO_INCREMENTAL: 0
@@ -41,12 +39,22 @@ jobs:
           ldd target/release/bamtofastq;
           ';
           mkdir ${{runner.temp}}/artifacts;
-          cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq-linux
+          cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq_linux
       - name: Upload build artifact
         uses: actions/upload-artifact@v1
         with:
           name: bamtofastq
           path: ${{runner.temp}}/artifacts
+      - name: Upload Linux
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{runner.temp}}/artifacts/bamtofastq_linux
+          asset_name: bamtofastq_linux
+          asset_content_type: application/octet-stream
+
   macos:
     runs-on: macos-10.15
     env:
@@ -65,53 +73,18 @@ jobs:
           target/release/bamtofastq --help | grep -q Usage
           otool -L target/release/bamtofastq
           mkdir ${{runner.temp}}/artifacts
-          cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq-macos
+          cp -a target/release/bamtofastq ${{runner.temp}}/artifacts/bamtofastq_macos
       - name: Upload build artifact
         uses: actions/upload-artifact@v1
         with:
           name: bamtofastq
           path: ${{runner.temp}}/artifacts
-
-  setup-release:
-    needs: [linux, macos]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: bamtofastq
-          path: ${{runner.temp}}/artifacts
-
-      - run: ls ${{runner.temp}}/artifacts
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        with:
-          tag_name: ${{github.ref}}
-          release_name: Release ${{github.ref}}
-          draft: false
-          prerelease: false
-
-      - name: Upload Linux
-        id: upload-linux-release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{runner.temp}}/artifacts/bamtofastq-linux
-          asset_name: bamtofastq_linux
-          asset_content_type: application/octet-stream
-
       - name: Upload Mac
-        id: upload-mac-release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{runner.temp}}/artifacts/bamtofastq-macos
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{runner.temp}}/artifacts/bamtofastq_macos
           asset_name: bamtofastq_macos
           asset_content_type: application/octet-stream

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt -- --check
       - name: build-bamtofastq
-        run: cargo build --release
+        run: cargo build --release --locked
       - name: unit tests
         run: cargo test --release -- --nocapture 
 
@@ -62,6 +62,6 @@ jobs:
             -W rust_2021_compatibility
             -W unused
       - name: build-bamtofastq
-        run: cargo build --release
+        run: cargo build --release --locked
       - name: unit tests
         run: cargo test --release -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "bamtofastq"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "backtrace",

--- a/README.md
+++ b/README.md
@@ -80,3 +80,22 @@ in the BAM file.
 
 * Multi-Gem Group BAM files created by Cell Ranger 1.2 and earlier do not carry Read Group tags, so reads from different GEM groups cannot be distinguished.
 * 'Unaligned' BAM files created by the BASIC pipeline in Long Ranger versions prior to 2.1.3, due to missing R1/R2 flags.
+
+## Maintenance
+
+### Releasing a new version
+
+To create a new release, the recommended steps are:
+
+1. Bump the version in `Cargo.toml`, and run `cargo check` to update the `Cargo.lock` file.
+2. Commit the changes (ideally in a new PR).
+3. When changes are in the `master` branch, go to the [releases] page and click on ["Draft a new release"].
+4. Enter the new version (or choose an existing tag) on the "Choose a tag" dropdown menu. Follow the `vX.Y.Z` tag format.
+5. Click on "Auto-generate release notes" to populate the release description. Review and make any changes (like limiting the number of `dependabot` changes to 1 line).
+6. Click on the "Publish release" button.
+
+Once the release is created there is an automated workflow for [publishing binaries] for Linux and macOS on new releases.
+
+[publishing binaries]: https://github.com/10XGenomics/bamtofastq/blob/master/.github/workflows/release.yaml
+[releases]: https://github.com/10XGenomics/bamtofastq/releases
+["Draft a new release"]: https://github.com/10XGenomics/bamtofastq/releases/new


### PR DESCRIPTION
The `1.4.1` release automation [failed](https://github.com/10XGenomics/bamtofastq/runs/5010943098?check_suite_focus=true#step:4:10) because I created the release with the GitHub UI (auto-drafted release notes are useful!), so this PR changes the automation to follow what our other repos do, with the benefit that if someone wants to create the tag in the CLI it will still work too.

I also added a small section to the README with suggested steps for creating a new release.

Finally, I forgot to update the `Cargo.lock` in #55 with the new version. Oops! (and that's why I added the release checklist to the README)