### PR TITLE
fix: clippy warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ struct SerFqSort;
 impl SortKey<SerFq> for SerFqSort {
     type Key = Vec<u8>;
 
-    fn sort_key(t: &SerFq) -> Cow<Vec<u8>> {
+    fn sort_key(t: &'_ SerFq) -> Cow<'_, Vec<u8>> {
         Cow::Borrowed(&t.header_key)
     }
 }


### PR DESCRIPTION
Was getting 
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/main.rs:161:20
    |
161 |     fn sort_key(t: &SerFq) -> Cow<Vec<u8>> {
    |                    ^^^^^^     ------------ the same lifetime is hidden here
    |                    |
    |                    the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
161 |     fn sort_key(t: &SerFq) -> Cow<'_, Vec<u8>> {
    |                      
```

fixes that